### PR TITLE
Revert "stylesheets/posts: don't restrict max width"

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -14,6 +14,7 @@
 
   img {
     border: 1px solid $black;
+	max-width: 100%;
   }
 
   pre {


### PR DESCRIPTION
This reverts commit baaef7a35a1f168f03913ee354eea4fe9bebed5f.

The problem is that on mobile devices images no longer shrink. I need to find a
better soltuion.